### PR TITLE
EDSC-3827: Update edsc-geo to use Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-          node-version: ['lts/hydrogen']
+          node-version: ['lts/fermium', 'lts/gallium', 'lts/hydrogen']
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-          node-version: ['lts/fermium', 'lts/gallium', 'lts/hydrogen']
+          node-version: ['lts/hydrogen', 'lts/iron']
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-          node-version: ['lts/hydrogen', 'lts/iron']
+          node-version: ['lts/hydrogen', 20]
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-          node-version: ['lts/gallium']
+          node-version: ['lts/hydrogen']
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-          node-version: ['lts/fermium', 'lts/gallium']
+          node-version: ['lts/hydrogen']
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/gallium
+lts/hydrogen

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@edsc/geo-utils",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@edsc/geo-utils",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/cli": "^7.17.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edsc/geo-utils",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Geographical utilities used by Earthdata Search",
   "main": "./dist/js/index.js",
   "scripts": {


### PR DESCRIPTION
# Overview

### What is the feature?

Update the node version for edsc-geo to the latest long term stable release `hydrogen`

### What is the Solution?

Update package.json, .nvmr, and the ci workflow for GH actions

### What areas of the application does this impact?

List impacted areas.

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. Step 1
2. Step 2...

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
