### PR TITLE
EDSC-4413: Fixes bug in dividePolygon when points included -180 or 180

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@edsc/geo-utils",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@edsc/geo-utils",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/cli": "^7.17.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edsc/geo-utils",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Geographical utilities used by Earthdata Search",
   "main": "./dist/js/index.js",
   "scripts": {

--- a/src/js/__tests__/geo.test.js
+++ b/src/js/__tests__/geo.test.js
@@ -109,6 +109,84 @@ describe('geo#dividePolygon', () => {
       ]
     })
   })
+
+  test('returns the boundaries and interiors of the polygon that touches but does cross the antimeridian', () => {
+    const polygon = [
+      {
+        lng: -180,
+        lat: 16.6
+      },
+      {
+        lng: 180,
+        lat: 16.6
+      },
+      {
+        lng: 180,
+        lat: 61.5
+      },
+      {
+        lng: -180,
+        lat: 61.5
+      },
+      {
+        lng: -180,
+        lat: 16.6
+      }
+    ]
+
+    const result = dividePolygon(polygon)
+
+    expect(result).toEqual({
+      interiors: [
+        [
+          {
+            lat: 16.6,
+            lng: -180
+          },
+          {
+            lat: 16.6,
+            lng: 180
+          },
+          {
+            lat: 61.5,
+            lng: 180
+          },
+          {
+            lat: 61.5,
+            lng: -180
+          },
+          {
+            lat: 16.6,
+            lng: -180
+          }
+        ]
+      ],
+      boundaries: [
+        [
+          {
+            lat: 16.6,
+            lng: -180
+          },
+          {
+            lat: 16.6,
+            lng: 180
+          },
+          {
+            lat: 61.5,
+            lng: 180
+          },
+          {
+            lat: 61.5,
+            lng: -180
+          },
+          {
+            lat: 16.6,
+            lng: -180
+          }
+        ]
+      ]
+    })
+  })
 })
 
 describe('geo#calculateArea', () => {

--- a/src/js/geo.js
+++ b/src/js/geo.js
@@ -212,11 +212,6 @@ const containsPole = (latlngs) => {
 
   delta *= RAD_TO_DEG
 
-  if (delta < (-360 + EPSILON)) {
-    // eslint-disable-next-line no-bitwise
-    return NORTH_POLE | SOUTH_POLE
-  }
-
   if (delta < EPSILON) {
     const angles = ((() => {
       const result1 = []
@@ -484,19 +479,19 @@ export const dividePolygon = (latlngs) => {
           [lat, -180]
         ]
       }
-    } else if ((latlng1.lng === 180) && (latlng2.lng < 0)) {
+    } else if ((latlng1.lng === 180) && (latlng2.lng < 0 && latlng2.lng !== -180)) {
       extras = [
         [latlng1.lat, -180]
       ]
-    } else if ((latlng1.lng === -180) && (latlng2.lng > 0)) {
+    } else if ((latlng1.lng === -180) && (latlng2.lng > 0 && latlng2.lng !== 180)) {
       extras = [
         [latlng1.lat, 180]
       ]
-    } else if ((latlng2.lng === 180) && (latlng1.lng < 0)) {
+    } else if ((latlng2.lng === 180) && (latlng1.lng < 0 && latlng1.lng !== -180)) {
       extras = [
         [latlng2.lat, -180]
       ]
-    } else if ((latlng2.lng === -180) && (latlng1.lng > 0)) {
+    } else if ((latlng2.lng === -180) && (latlng1.lng > 0 && latlng1.lng !== 180)) {
       extras = [
         [latlng2.lat, 180]
       ]


### PR DESCRIPTION
# Overview

### What is the feature?

When given a polygon that contains longitude -180 or 180, the dividePolygon function incorrectly splits the polygon.

### What is the Solution?

Summarize what you changed.

### What areas of the application does this impact?

List impacted areas.

# Testing

Locally run `npm pack`, then from EDSC run `npm install /path/to/edsc-geo-utils-1.0.7.tgz`
[This is the granule](http://localhost:8080/search/granules?p=C2609887645-LARC_ASDC&pg[0][v]=f&pg[0][id]=ACCLIP-mrg60-WB57_merge_20220910_RE.ict&pg[0][gsk]=-start_date&q=C2609887645-LARC_ASDC&tl=1660564799.5!3!!&lat=3.2550816051738813&long=4.279033272893046&zoom=1.4761118722537758) I used in the new test within geo.test.js.
I also found these examples of incorrect geometry that are now fixed. [Here](http://localhost:8080/search/granules?p=C3091018780-LARC_ASDC&pg[0][v]=f&pg[0][id]=CER_CCCM_Aqua-FM3-MODIS-CAL-CS_RelD2_908909.20171222.hdf&pg[0][gsk]=-start_date&q=CER_CCCM_Aqua-FM3-MODIS-CAL-CS_RelD2&sb[0]=-88.03125%2C41.74835%2C-87.61816%2C42.07806&tl=1333195200!5!!&lat=53.917143364429315&long=-83.41695502639921&zoom=2.754821632872357) and [Here](http://localhost:8080/search/granules?p=C1982417666-LARC_ASDC&pg[0][v]=f&pg[0][id]=DSCOVR_EPIC_L2_CLOUD_03_20250208184618_03.nc4&pg[0][gsk]=-start_date&q=EPIC&sb[0]=-112.5%2C-88.77434%2C-106.3125%2C-86.52259&qt=2025-02-07T01%3A54%3A36.010Z%2C2025-02-08T23%3A45%3A22.052Z&tl=1588816845.239!4!!&lat=-12.2428045076871&long=-115.66244672778252&zoom=1.8016765432071629)
(compare with prod)

### Attachments

Before
<img width="1148" alt="Screenshot 2025-03-31 at 12 58 09 PM" src="https://github.com/user-attachments/assets/7009339f-f027-463a-816d-dcfed295f15a" />
After
<img width="1012" alt="Screenshot 2025-03-31 at 12 59 03 PM" src="https://github.com/user-attachments/assets/c1fde3b3-29ee-416f-88a7-d73a47172e7d" />


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
